### PR TITLE
feat(collector): add Apache HTTP Server collector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4929,6 +4929,7 @@ dependencies = [
  "config",
  "httpmock",
  "polars",
+ "regex",
  "reqwest",
  "rss",
  "scraper",

--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ GitHub Actions automatically runs the same checks on every push and pull request
 
 Contributions are what make the open source community such an amazing place to learn, inspire, and create. Any contributions you make are **greatly appreciated**.
 
+➡️ **To add support for a new software (collector), see:** [How to Add a Software Collector](docs/add_software_collector.md)
+
 If you have a suggestion that would make this better, please fork the repo and create a pull request. You can also simply open an issue with the tag "enhancement".
 Don't forget to give the project a star! Thanks again!
 

--- a/config/base.yml
+++ b/config/base.yml
@@ -48,4 +48,7 @@ targets:
 
   - name: "kong"
     enabled: true
+
+  - name: "apache"
+    enabled: true
     

--- a/crates/versionwatch-cli/src/main.rs
+++ b/crates/versionwatch-cli/src/main.rs
@@ -4,11 +4,11 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 use tracing_subscriber::{EnvFilter, prelude::*};
 use versionwatch_collect::{
-    Collector, docker::DockerCollector, eclipse_temurin::EclipseTemurinCollector,
-    elixir::ElixirCollector, go::GoCollector, kong::KongCollector, kotlin::KotlinCollector,
-    nginx::NginxCollector, node::NodeCollector, perl::PerlCollector, php::PhpCollector,
-    python::PythonCollector, ruby::RubyCollector, rust::RustCollector, scala::ScalaCollector,
-    swift::SwiftCollector,
+    Collector, apache::ApacheCollector, docker::DockerCollector,
+    eclipse_temurin::EclipseTemurinCollector, elixir::ElixirCollector, go::GoCollector,
+    kong::KongCollector, kotlin::KotlinCollector, nginx::NginxCollector, node::NodeCollector,
+    perl::PerlCollector, php::PhpCollector, python::PythonCollector, ruby::RubyCollector,
+    rust::RustCollector, scala::ScalaCollector, swift::SwiftCollector,
 };
 use versionwatch_config::load as load_config;
 use versionwatch_core::domain::software_version::SoftwareVersion;
@@ -53,6 +53,7 @@ async fn main() -> Result<()> {
             "kotlin" => Arc::new(KotlinCollector::new(github_token.clone())),
             "swift" => Arc::new(SwiftCollector::new(github_token.clone())),
             "perl" => Arc::new(PerlCollector {}),
+            "apache" => Arc::new(ApacheCollector::new()),
             _ => {
                 tracing::warn!("Unknown target: {}", target.name);
                 continue;

--- a/crates/versionwatch-collect/Cargo.toml
+++ b/crates/versionwatch-collect/Cargo.toml
@@ -17,6 +17,7 @@ thiserror = { workspace = true }
 rss = "2.0"
 scraper = "0.23"
 tracing = { workspace = true }
+regex = "1.11.1"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/versionwatch-collect/src/apache.rs
+++ b/crates/versionwatch-collect/src/apache.rs
@@ -1,0 +1,85 @@
+use super::{Collector, Error};
+use async_trait::async_trait;
+use polars::prelude::*;
+use regex::Regex;
+use reqwest::StatusCode;
+use std::collections::BTreeSet;
+
+pub struct ApacheCollector;
+
+impl ApacheCollector {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for ApacheCollector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Collector for ApacheCollector {
+    fn name(&self) -> &'static str {
+        "apache"
+    }
+
+    async fn collect(&self) -> Result<DataFrame, Error> {
+        let url = "https://downloads.apache.org/httpd/";
+        let client = reqwest::Client::new();
+        let response = client
+            .get(url)
+            .header("User-Agent", "versionwatch-collector")
+            .send()
+            .await
+            .map_err(|e| Error::Other(format!("Failed to fetch Apache download page: {e}")))?;
+
+        if response.status() != StatusCode::OK {
+            return Err(Error::Other(format!(
+                "Apache download page returned status {}",
+                response.status()
+            )));
+        }
+
+        let body = response
+            .text()
+            .await
+            .map_err(|e| Error::Other(format!("Failed to read Apache download page: {e}")))?;
+
+        // Regex: httpd-2.4.59.tar.gz, ignore alpha/beta/rc
+        let re = Regex::new(r"httpd-(\d+)\.(\d+)\.(\d+)\.tar\.gz").unwrap();
+        let mut versions = BTreeSet::new();
+        for cap in re.captures_iter(&body) {
+            let major: u32 = cap[1].parse().unwrap_or(0);
+            let minor: u32 = cap[2].parse().unwrap_or(0);
+            let patch: u32 = cap[3].parse().unwrap_or(0);
+            // Only consider 2.x.x and above (ignore legacy 1.x)
+            if major >= 2 {
+                versions.insert((major, minor, patch));
+            }
+        }
+
+        let latest = versions.iter().next_back();
+        let latest_version = match latest {
+            Some((major, minor, patch)) => format!("{major}.{minor}.{patch}"),
+            None => {
+                tracing::error!("No stable Apache version found on download page");
+                return Err(Error::Other("No stable Apache version found".to_string()));
+            }
+        };
+
+        let df = polars::df!(
+            "name" => &["apache"],
+            "current_version" => &[None::<String>],
+            "latest_version" => &[latest_version],
+            "latest_lts_version" => &[None::<String>],
+            "is_lts" => &[false],
+            "eol_date" => &[None::<i64>],
+            "release_notes_url" => &[Some("https://downloads.apache.org/httpd/".to_string())],
+            "cve_count" => &[0_i32],
+        )
+        .map_err(|e| Error::Other(e.to_string()))?;
+        Ok(df)
+    }
+}

--- a/crates/versionwatch-collect/src/lib.rs
+++ b/crates/versionwatch-collect/src/lib.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use polars::prelude::*;
 
+pub mod apache;
 pub mod docker;
 pub mod eclipse_temurin;
 pub mod elixir;
@@ -58,4 +59,5 @@ pub trait Collector: Send + Sync {
     async fn collect(&self) -> Result<DataFrame, Error>;
 }
 
+pub use apache::ApacheCollector;
 pub use kong::KongCollector;

--- a/docs/add_software_collector.md
+++ b/docs/add_software_collector.md
@@ -1,0 +1,126 @@
+# Adding a New Software Collector to VersionWatch
+
+This guide explains how to add support for a new software ("collector") in the VersionWatch project. Follow these steps to ensure your contribution is robust, maintainable, and consistent with project standards.
+
+---
+
+## 1. Overview
+
+A "collector" is a Rust struct implementing the `Collector` trait, responsible for fetching the latest version (and optionally LTS/EOL info) for a given software. Each collector is a separate file in `crates/versionwatch-collect/src/`.
+
+---
+
+## 2. Steps to Add a New Collector
+
+### 2.1. Create the Collector File
+- Create a new file: `crates/versionwatch-collect/src/<software>.rs`
+- Use an existing collector (e.g., `nginx.rs`, `docker.rs`, `python.rs`) as a template.
+
+### 2.2. Implement the Collector
+- Define a struct (e.g., `MySoftwareCollector`).
+- Implement the `Collector` trait for your struct.
+- Fetch data from the official API, website, or GitHub releases/tags.
+- Parse and normalize the version string(s).
+- Fill all required DataFrame columns:
+  - `name`, `current_version`, `latest_version`, `latest_lts_version`, `is_lts`, `eol_date`, `release_notes_url`, `cve_count`
+- Handle errors using the `Error` enum from `lib.rs`.
+- Handle API rate limiting and edge cases explicitly.
+
+### 2.3. Register the Collector
+- In `crates/versionwatch-collect/src/lib.rs`:
+  - Add `pub mod <software>;` at the top.
+  - Add `pub use <software>::<MySoftwareCollector>;` at the bottom.
+- In `crates/versionwatch-cli/src/main.rs`:
+  - Import your collector.
+  - Add a match arm in the collector registration (see other collectors for pattern).
+
+### 2.4. Update the Configuration
+- In `config/base.yml`, add an entry:
+  ```yaml
+  - name: "<software>"
+    enabled: true
+  ```
+- The `name` must match the collector's `fn name()` return value.
+
+### 2.5. Test Your Collector
+- Run `cargo run --bin versionwatch-cli` and verify your software appears in the output.
+- Check for correct version, release notes, and error handling.
+- Run `cargo clippy --all-targets --all-features -- -D warnings` and `cargo fmt`.
+- Add or update tests if needed (see other collectors for test patterns).
+
+### 2.6. Document and Commit
+- Document any API quirks or parsing logic in code comments.
+- Update the main `README.md` to mention your new collector (see below).
+- Commit your changes with a clear message.
+
+---
+
+## 3. Example: Adding "example-soft"
+
+1. Create `crates/versionwatch-collect/src/example_soft.rs`:
+   ```rust
+   use super::{Collector, Error};
+   use async_trait::async_trait;
+   use polars::prelude::*;
+
+   pub struct ExampleSoftCollector;
+
+   #[async_trait]
+   impl Collector for ExampleSoftCollector {
+       fn name(&self) -> &'static str { "example-soft" }
+       async fn collect(&self) -> Result<DataFrame, Error> {
+           // Fetch and parse version info here
+           let df = df!(
+               "name" => &["example-soft"],
+               "current_version" => &[None::<String>],
+               "latest_version" => &["1.2.3"],
+               "latest_lts_version" => &[None::<String>],
+               "is_lts" => &[false],
+               "eol_date" => &[None::<i64>],
+               "release_notes_url" => &[Some("https://example.com/release".to_string())],
+               "cve_count" => &[0_i32],
+           )?;
+           Ok(df)
+       }
+   }
+   ```
+2. Register in `lib.rs` and `main.rs` as described above.
+3. Add to `config/base.yml`:
+   ```yaml
+   - name: "example-soft"
+     enabled: true
+   ```
+4. Test and document.
+
+---
+
+## 4. Best Practices & Checklist
+
+- [ ] Use clear, robust error handling (no panics)
+- [ ] Handle API rate limiting and edge cases
+- [ ] Use the same DataFrame schema as other collectors
+- [ ] Add code comments for non-obvious logic
+- [ ] Run `cargo fmt` and `cargo clippy --all-targets --all-features -- -D warnings`
+- [ ] Test manually and/or add automated tests
+- [ ] Update documentation (this file and README)
+- [ ] Use a clear, conventional commit message
+
+---
+
+## 5. Useful Links
+- [Collector trait definition](../crates/versionwatch-collect/src/lib.rs)
+- [Example collector: nginx.rs](../crates/versionwatch-collect/src/nginx.rs)
+- [Configuration file](../config/base.yml)
+- [CLI main file](../crates/versionwatch-cli/src/main.rs)
+
+---
+
+## 6. Updating the README
+
+After adding your collector, update the `README.md` to:
+- List your software in the "Supported Software" section
+- Optionally, add a note about the data source/API used
+
+---
+
+Thank you for contributing to VersionWatch! 


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description

Add a new collector for Apache HTTP Server:
- Implements a new `apache` collector that parses the official Apache download page to extract the latest stable version.
- Returns data in the standard schema (8 columns) for compatibility with the workspace.
- Integrated into the workspace, configuration (`config/base.yml`), and CLI.
- Follows project error handling and data model conventions.
- Appears in CLI output and database.
- Fully tested: build, lint, run all OK.

## ✅ Checklist

- [x] My code builds and runs cleanly
- [x] I have added/updated tests if needed (manual test via CLI)
- [x] I have run `cargo fmt` and `cargo clippy`
- [x] I have updated documentation if necessary
- [x] I have manually tested the feature

## 🧪 How to test

1. Run `cargo run --bin versionwatch-cli`
2. Check that the `apache` row appears with the latest stable version in the output table.
3. Verify no errors or schema mismatches.

## 🛠️ Breaking changes

- [ ] Yes (describe below)
- [x] No

## 📸 Screenshots (if applicable)

<!-- N/A -->

## 🗣️ Additional notes

- The collector uses the official Apache download page, which is stable and reliable for version tracking.
- All code follows project standards and is ready for review and merge. 