### PR TITLE
feat(collector): Add new collector for Caddy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ logs/
 .idea/
 .vscode/
 .cursor/
+.cursorrules
 .windsurf/
 *.sublime-project
 *.sublime-workspace

--- a/config/base.yml
+++ b/config/base.yml
@@ -51,4 +51,7 @@ targets:
 
   - name: "apache"
     enabled: true
+
+  - name: "caddy"
+    enabled: true
     

--- a/crates/versionwatch-cli/src/main.rs
+++ b/crates/versionwatch-cli/src/main.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 use tracing_subscriber::{EnvFilter, prelude::*};
 use versionwatch_collect::{
-    Collector, apache::ApacheCollector, docker::DockerCollector,
+    Collector, apache::ApacheCollector, caddy::CaddyCollector, docker::DockerCollector,
     eclipse_temurin::EclipseTemurinCollector, elixir::ElixirCollector, go::GoCollector,
     kong::KongCollector, kotlin::KotlinCollector, nginx::NginxCollector, node::NodeCollector,
     perl::PerlCollector, php::PhpCollector, python::PythonCollector, ruby::RubyCollector,
@@ -40,6 +40,7 @@ async fn main() -> Result<()> {
         let collector: Arc<dyn Collector> = match target.name.as_str() {
             "node" => Arc::new(NodeCollector {}),
             "docker" => Arc::new(DockerCollector::new(github_token.clone())),
+            "caddy" => Arc::new(CaddyCollector::new(github_token.clone())),
             "rust" => Arc::new(RustCollector::new(github_token.clone())),
             "python" => Arc::new(PythonCollector::new(github_token.clone())),
             "eclipse-temurin" => Arc::new(EclipseTemurinCollector {}),

--- a/crates/versionwatch-collect/src/caddy.rs
+++ b/crates/versionwatch-collect/src/caddy.rs
@@ -1,0 +1,76 @@
+use super::{Collector, Error, GitHubRelease};
+use async_trait::async_trait;
+use polars::prelude::*;
+
+pub struct CaddyCollector {
+    github_token: Option<String>,
+}
+
+impl CaddyCollector {
+    pub fn new(github_token: Option<String>) -> Self {
+        Self { github_token }
+    }
+}
+
+#[async_trait]
+impl Collector for CaddyCollector {
+    fn name(&self) -> &'static str {
+        "caddy"
+    }
+
+    async fn collect(&self) -> Result<DataFrame, Error> {
+        let url = "https://api.github.com/repos/caddyserver/caddy/releases";
+        let client = reqwest::Client::new();
+        let mut request = client
+            .get(url)
+            .header("User-Agent", "versionwatch-collector")
+            .header("Accept", "application/vnd.github.v3+json");
+        if let Some(token) = &self.github_token {
+            request = request.bearer_auth(token);
+        }
+
+        let response = request.send().await?;
+        if response.status() == reqwest::StatusCode::FORBIDDEN
+            || response.status() == reqwest::StatusCode::TOO_MANY_REQUESTS
+        {
+            if let Some(remaining) = response.headers().get("x-ratelimit-remaining") {
+                if remaining == "0" {
+                    let reset = response
+                        .headers()
+                        .get("x-ratelimit-reset")
+                        .and_then(|v| v.to_str().ok())
+                        .and_then(|s| s.parse::<u64>().ok());
+                    let wait = reset.unwrap_or(0);
+                    let wait_msg =
+                        format!("GitHub API rate limit exceeded. Try again in {wait} seconds.");
+                    return Err(Error::RateLimited(wait_msg));
+                }
+            }
+            return Err(Error::Other(format!(
+                "GitHub API returned forbidden or rate limited: {}",
+                response.status()
+            )));
+        }
+        let releases: Vec<GitHubRelease> = response.json().await?;
+
+        let latest_release = releases
+            .into_iter()
+            .find(|r| !r.prerelease && !r.draft)
+            .ok_or(Error::NotFound)?;
+
+        let version = latest_release.tag_name.trim_start_matches('v').to_string();
+
+        let df = df!(
+            "name" => &["caddy"],
+            "current_version" => &[""],
+            "latest_version" => &[version],
+            "latest_lts_version" => &[None::<String>],
+            "is_lts" => &[false],
+            "eol_date" => &[None::<i64>],
+            "release_notes_url" => &[Some(latest_release.html_url)],
+            "cve_count" => &[0_i32],
+        )?;
+
+        Ok(df)
+    }
+}

--- a/crates/versionwatch-collect/src/lib.rs
+++ b/crates/versionwatch-collect/src/lib.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use polars::prelude::*;
 
 pub mod apache;
+pub mod caddy;
 pub mod docker;
 pub mod eclipse_temurin;
 pub mod elixir;
@@ -62,5 +63,10 @@ pub trait Collector: Send + Sync {
 }
 
 pub use apache::ApacheCollector;
+pub use caddy::CaddyCollector;
+pub use docker::DockerCollector;
+pub use eclipse_temurin::EclipseTemurinCollector;
+pub use elixir::ElixirCollector;
 pub use kong::KongCollector;
 pub use php::PhpCollector;
+pub use python::PythonCollector;


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description

This pull request introduces a new version collector for the **Caddy** web server.

Following the project's contribution guide (`docs/add_software_collector.md`), this implementation includes:
- A new `CaddyCollector` struct in `crates/versionwatch-collect/src/caddy.rs`.
- The collector fetches the latest stable release from the official `caddyserver/caddy` GitHub repository.
- Integration of the collector into the main application binary (`crates/versionwatch-cli/src/main.rs`).
- Activation of the collector in the default configuration file (`config/base.yml`).

## ✅ Checklist

- [x] My code builds and runs cleanly
- [ ] I have added/updated tests if needed *(No specific unit tests were added, but the feature was tested via `cargo run`)*
- [x] I have run `cargo fmt` and `cargo clippy`
- [ ] I have updated documentation if necessary *(Note: The main `README.md` could be updated to list Caddy as a supported software)*
- [x] I have manually tested the feature

## 🧪 How to test

1.  Check out this branch:
    ```bash
    git checkout feature/add-caddy-collector
    ```
2.  Ensure your environment is set up (e.g., `.env` file with `GITHUB_TOKEN` if needed to avoid rate limiting).
3.  Run the application:
    ```bash
    cargo run --bin versionwatch-cli
    ```
4.  Verify that the output table contains a row for `caddy` with the latest version fetched, similar to this:
    ```
    │ caddy     ┆           ┆ 2.10.0    ┆ null     ┆ false  ┆ null     ┆ https://... │
    ```

## 🛠️ Breaking changes

- [x] No

## 📸 Screenshots (if applicable)

N/A

## 🗣️ Additional notes

This implementation closely follows the existing pattern for GitHub-based collectors like `nginx`, ensuring consistency with the current codebase.
